### PR TITLE
Don't call showMentionsListWithString after deleting the trigger

### DIFF
--- a/SZMentionsSwift/Classes/SZMentionsListener.swift
+++ b/SZMentionsSwift/Classes/SZMentionsListener.swift
@@ -660,7 +660,7 @@ open class SZMentionsListener: NSObject, UITextViewDelegate {
      @param timer: the timer that called the method
      */
     internal func cooldownTimerFired(_ timer: Timer) {
-        if ((self.filterString?.characters.count) != nil  && self.filterString != self.stringCurrentlyBeingFiltered) {
+        if ((self.filterString?.characters.count) != nil  && self.filterString != self.stringCurrentlyBeingFiltered && self.mentionEnabled) {
             self.stringCurrentlyBeingFiltered = filterString
             self.mentionsManager.showMentionsListWithString(filterString!)
         }


### PR DESCRIPTION
Added a check in cooldownTimerFired to avoid calling showMentionsListWithString when you are deleting quickly a mention.
