### PR TITLE
minor clean up

### DIFF
--- a/SZMentionsSwift/Classes/Private/NSMutableAttributedString+Attributes.swift
+++ b/SZMentionsSwift/Classes/Private/NSMutableAttributedString+Attributes.swift
@@ -11,7 +11,6 @@ internal extension NSMutableAttributedString {
      @brief Applies attributes to a given string and range
      @param attributes: the attributes to apply
      @param range: the range to apply the attributes to
-     @param mutableAttributedString: the string to apply the attributes to
      */
     func apply(_ attributes: [AttributeContainer], range: NSRange) {
         attributes.forEach { attribute in

--- a/SZMentionsSwift/Classes/Private/SZAttribute.swift
+++ b/SZMentionsSwift/Classes/Private/SZAttribute.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public class SZAttribute: AttributeContainer {
+public struct SZAttribute: AttributeContainer {
     /**
      @brief Name of the attribute to set on a string
      */
@@ -18,14 +18,4 @@ public class SZAttribute: AttributeContainer {
      @brief Value of the attribute to set on a string
      */
     public var attributeValue: NSObject
-    
-    /**
-     @brief initializer for creating an attribute
-     @param attributeName: the name of the attribute (example: NSForegroundColorAttributeName)
-     @param attributeValue: the value for the given attribute (example: UIColor.redColor)
-     */
-    public init(attributeName: String, attributeValue: NSObject) {
-        self.attributeName = attributeName
-        self.attributeValue = attributeValue
-    }
 }

--- a/SZMentionsSwift/Classes/Private/SZMentionArray+AddOns.swift
+++ b/SZMentionsSwift/Classes/Private/SZMentionArray+AddOns.swift
@@ -22,7 +22,6 @@ internal extension Array where Element: SZMention {
      @brief adjusts the positioning of mentions that exist after the range where text was edited
      @param range: the range where text was changed
      @param text: the text that was changed
-     @param mentions: the list of current mentions
      */
     func adjustMentions(forTextChangeAtRange range: NSRange, text: String) {
         let rangeAdjustment = text.utf16.count - range.length
@@ -36,7 +35,6 @@ internal extension Array where Element: SZMention {
     /**
      @brief Determines what mentions exist after a given range
      @param range: the range where text was changed
-     @param mentionsList: the list of current mentions
      @return [SZMention]: list of mentions that exist after the provided range
      */
     private func mentionsAfterTextEntry(_ range: NSRange) -> [SZMention] {

--- a/SZMentionsSwift/Classes/Private/SZVerifier.swift
+++ b/SZMentionsSwift/Classes/Private/SZVerifier.swift
@@ -1,3 +1,11 @@
+//
+//  SZMentionHelper.swift
+//  SZMentionsSwift
+//
+//  Created by Steve Zweier on 2/1/16.
+//  Copyright © 2016 Steven Zweier. All rights reserved.
+//
+
 internal class SZVerifier {
     static let attributeConsistencyError = "Default and mention attributes must contain the same attribute names: If default attributes specify NSForegroundColorAttributeName mention attributes must specify that same name as well. (Values do not need to match)"
 

--- a/SZMentionsSwift/Classes/Private/StringHelpers.swift
+++ b/SZMentionsSwift/Classes/Private/StringHelpers.swift
@@ -1,7 +1,15 @@
+//
+//  SZMentionHelper.swift
+//  SZMentionsSwift
+//
+//  Created by Steve Zweier on 2/1/16.
+//  Copyright © 2016 Steven Zweier. All rights reserved.
+//
+
 import UIKit
 
 extension String {
-    func range(of strings: [String], options: NSString.CompareOptions, range: NSRange? = nil) -> (range: NSRange?, foundString: String?) {
+    internal func range(of strings: [String], options: NSString.CompareOptions, range: NSRange? = nil) -> (range: NSRange?, foundString: String?) {
         guard !strings.isEmpty else { return (nil, nil) }
         var i = 0
         var foundRange: NSRange?

--- a/SZMentionsSwift/Classes/SZMentionsListener.swift
+++ b/SZMentionsSwift/Classes/SZMentionsListener.swift
@@ -36,69 +36,69 @@ public class SZMentionsListener: NSObject {
     /**
      @brief Triggers to start a mention. Default: @
      */
-    fileprivate var triggers: [String]
+    private var triggers: [String]
 
     /**
      @brief Text attributes to be applied to all text excluding mentions.
      */
-    fileprivate var defaultTextAttributes: [AttributeContainer]
+    private var defaultTextAttributes: [AttributeContainer]
 
     /**
      @brief Text attributes to be applied to mentions.
      */
-    fileprivate var mentionTextAttributes: [AttributeContainer]
+    private var mentionTextAttributes: [AttributeContainer]
 
     /**
      @brief The UITextView being handled by the SZMentionsListener
      */
-    fileprivate var mentionsTextView: UITextView
+    private var mentionsTextView: UITextView
 
     /**
      @brief Manager in charge of handling the creation and dismissal of the mentions
      list.
      */
-    fileprivate var mentionsManager: MentionsManagerDelegate
+    private var mentionsManager: MentionsManagerDelegate
 
     /**
      @brief Amount of time to delay between showMentions calls default:0.5
      */
-    fileprivate var cooldownInterval: TimeInterval
+    private var cooldownInterval: TimeInterval
 
     /**
      @brief Mutable array list of mentions managed by listener, accessible via the
      public mentions property.
      */
-    fileprivate var mutableMentions: [SZMention] = []
+    private var mutableMentions: [SZMention] = []
 
     /**
      @brief Range of mention currently being edited.
      */
-    fileprivate var currentMentionRange: NSRange?
+    private var currentMentionRange: NSRange?
 
     /**
      @brief Whether or not we are currently editing a mention.
      */
-    fileprivate var editingMention: Bool = false
+    private var editingMention: Bool = false
 
     /**
      @brief String to filter by
      */
-    fileprivate var filterString: String?
+    private var filterString: String?
 
     /**
      @brief String that has been sent to the showMentionsListWithString
      */
-    fileprivate var stringCurrentlyBeingFiltered: String?
+    private var stringCurrentlyBeingFiltered: String?
 
     /**
      @brief Timer to space out mentions requests
      */
-    fileprivate var cooldownTimer: Timer?
+    private var cooldownTimer: Timer?
 
     /**
      @brief Whether or not a mention is currently being edited
      */
-    fileprivate var mentionEnabled = false
+    private var mentionEnabled = false
 
     // MARK: Initialization
     /**
@@ -260,7 +260,7 @@ extension SZMentionsListener {
      @brief Reset typingAttributes for textView
      @param textView: the textView to change the typingAttributes on
      */
-    fileprivate func resetTypingAttributes(for textView: UITextView) {
+    private func resetTypingAttributes(for textView: UITextView) {
         var attributes = [String: Any]()
         for attribute in defaultTextAttributes {
             attributes[attribute.attributeName] = attribute.attributeValue
@@ -272,7 +272,7 @@ extension SZMentionsListener {
      @brief Resets the empty text view
      @param textView: the text view to reset
      */
-    fileprivate func resetEmpty(_ textView: UITextView) {
+    private func resetEmpty(_ textView: UITextView) {
         mutableMentions.removeAll()
         resetTypingAttributes(for: textView)
         textView.text = " "
@@ -290,7 +290,7 @@ extension SZMentionsListener {
      @param textView: the mentions text view
      @param range: the selected range
      */
-    fileprivate func adjust(_ textView: UITextView, range: NSRange) {
+    private func adjust(_ textView: UITextView, range: NSRange) {
         let string = (textView.text as NSString).substring(to: range.location)
         var textBeforeTrigger = " "
         let rangeTuple = string.range(of: triggers, options: NSString.CompareOptions.backwards)
@@ -342,7 +342,7 @@ extension SZMentionsListener {
         mentionEnabled = false
     }
     
-    fileprivate func clearMention(_ mention: SZMention) {
+    private func clearMention(_ mention: SZMention) {
         if let index = mutableMentions.index(of: mention) {
             editingMention = true
             mutableMentions.remove(at: index)
@@ -360,7 +360,7 @@ extension SZMentionsListener {
      @param text: the text to replace the range with
      @return Bool: whether or not the textView should adjust the text itself
      */
-    @discardableResult fileprivate func shouldAdjust(_ textView: UITextView, range: NSRange, text: String) -> Bool {
+    @discardableResult private func shouldAdjust(_ textView: UITextView, range: NSRange, text: String) -> Bool {
         var shouldAdjust = true
 
         if textView.text.isEmpty { resetEmpty(textView) }


### PR DESCRIPTION
• Move to private where fileprivate was originally needed.
• Insert missing header.
• Remove incorrect comments.