### PR TITLE
Search spaces crash

### DIFF
--- a/SZMentionsSwift/Classes/MentionListener.swift
+++ b/SZMentionsSwift/Classes/MentionListener.swift
@@ -251,6 +251,8 @@ extension MentionListener /* Private */ {
 
         if location != NSNotFound {
             (mentionEnabled, textBeforeTrigger) = mentionsTextView.text.isMentionEnabledAt(location)
+        } else {
+            mentionEnabled = false
         }
 
         if mentionEnabled {

--- a/SZMentionsSwift/SZMentionsSwiftTests/AddingMentionsTests.swift
+++ b/SZMentionsSwift/SZMentionsSwiftTests/AddingMentionsTests.swift
@@ -241,6 +241,14 @@ class AddingMentions: QuickSpec {
                 expect(textView.text.utf16.count).to(equal(5))
             }
 
+            it("Should test that text can be added and removed without crashes when search spaces is true.") {
+                mentionsListener = generateMentionsListener(spaceAfterMention: false, searchSpaces: true)
+                update(text: "@s", type: .insert, on: mentionsListener)
+                update(text: "", type: .delete, on: mentionsListener)
+                update(text: "", type: .delete, on: mentionsListener)
+                expect(textView.text.isEmpty).to(beTruthy())
+            }
+
             func generateMentionsListener(spaceAfterMention: Bool, searchSpaces: Bool) -> MentionListener {
                 let attribute = Attribute(name: .foregroundColor, value: UIColor.red)
                 let attribute2 = Attribute(name: .foregroundColor, value: UIColor.black)


### PR DESCRIPTION
Added a test case which tests adding and removing text while `searchSpaces = true`.
Implemented a potential fix for the crash that happens in this case.

Merging this can also close #102.