### PR TITLE
Fix range bound crash when startIndex greater than or equal to endIndex

### DIFF
--- a/Classes/MentionListener.swift
+++ b/Classes/MentionListener.swift
@@ -268,7 +268,9 @@ extension MentionListener /* Private */ {
             if searchSpaces {
                 let startIndex = mentionsTextView.text.utf16.index(mentionsTextView.text.startIndex, offsetBy: location)
                 let endIndex = mentionsTextView.text.utf16.index(startIndex, offsetBy: NSMaxRange(textView.selectedRange) - location)
-                mentionString = String(mentionsTextView.text[startIndex ..< endIndex])
+                if startIndex < endIndex {
+                    mentionString = String(mentionsTextView.text[startIndex ..< endIndex])
+                }
             } else if let stringBeingTyped = stringToSelectedIndex.components(separatedBy: textBeforeTrigger).last,
                 let stringForMention = stringBeingTyped.components(separatedBy: " ").last,
                 stringForMention.range(of: trigger, options: .anchored) != nil {


### PR DESCRIPTION
Range bound will crash when startIndex greater than or equal to endIndex in some case.