### PR TITLE
Deletion callback; replace edited mention; start mention without " " before

### DIFF
--- a/Classes/Internal/String.swift
+++ b/Classes/Internal/String.swift
@@ -26,13 +26,17 @@ internal extension String {
         return (foundRange, string)
     }
 
-    func isMentionEnabledAt(_ location: Int) -> (Bool, String) {
+    func isMentionEnabledAt(_ location: Int, considerTextBefore: Bool = true) -> (Bool, String) {
         guard location != 0 else { return (true, "") }
 
         let start = utf16.index(startIndex, offsetBy: location - 1)
         let end = utf16.index(start, offsetBy: 1)
         let textBeforeTrigger = String(utf16[start ..< end]) ?? ""
 
-        return (textBeforeTrigger == " " || textBeforeTrigger == "\n", textBeforeTrigger)
+        if considerTextBefore {
+            return (textBeforeTrigger == " " || textBeforeTrigger == "\n", textBeforeTrigger)
+        } else {
+            return (true, textBeforeTrigger)
+        }
     }
 }

--- a/Classes/MentionListener.swift
+++ b/Classes/MentionListener.swift
@@ -278,7 +278,6 @@ extension MentionListener /* Private */ {
             let cursorPosition = textView.offset(from: textView.beginningOfDocument, to: selectedRange.end)
             let positionRange = NSRange(location: 0, length: cursorPosition)
             if let stringOffset = Range(positionRange, in: textView.text) {
-                print(stringOffset.upperBound)
                 endIndex = stringOffset.upperBound
             }
         }

--- a/Classes/MentionListener.swift
+++ b/Classes/MentionListener.swift
@@ -218,7 +218,6 @@ extension MentionListener /* Public */ {
      */
     @discardableResult public func addMention(_ createMention: CreateMention) -> Bool {
         guard currentMentionRange.location != NSNotFound else { return false }
-        
         if let mention = mentions |> mentionBeingEdited(at: currentMentionRange), replaceEditedMention {
             mention |> clearMention()
         }
@@ -271,8 +270,19 @@ extension MentionListener /* Private */ {
      */
     private func handleMentionsList(_ textView: UITextView, range: NSRange) {
         let startIndex = mentionsTextView.text.startIndex
-        let endIndex = mentionsTextView.text.index(startIndex,
+        var endIndex = mentionsTextView.text.index(startIndex,
                                                    offsetBy: min(NSMaxRange(range), mentionsTextView.text.count))
+        // Need to convert NSRange and the offset to String.Index
+        // in order to handle emojis character count case
+        if let selectedRange = textView.selectedTextRange {
+            let cursorPosition = textView.offset(from: textView.beginningOfDocument, to: selectedRange.end)
+            let positionRange = NSRange(location: 0, length: cursorPosition)
+            if let stringOffset = Range(positionRange, in: textView.text) {
+                print(stringOffset.upperBound)
+                endIndex = stringOffset.upperBound
+            }
+        }
+        
         let stringToSelectedIndex = String(mentionsTextView.text[startIndex ..< endIndex])
 
         var textBeforeTrigger = " "
@@ -317,7 +327,6 @@ extension MentionListener /* Private */ {
                 return
             }
         }
-        
         hideMentions()
     }
 

--- a/Classes/MentionListener.swift
+++ b/Classes/MentionListener.swift
@@ -218,6 +218,7 @@ extension MentionListener /* Public */ {
      */
     @discardableResult public func addMention(_ createMention: CreateMention) -> Bool {
         guard currentMentionRange.location != NSNotFound else { return false }
+        
         if let mention = mentions |> mentionBeingEdited(at: currentMentionRange), replaceEditedMention {
             mention |> clearMention()
         }
@@ -316,6 +317,7 @@ extension MentionListener /* Private */ {
                 return
             }
         }
+        
         hideMentions()
     }
 

--- a/Classes/MentionListener.swift
+++ b/Classes/MentionListener.swift
@@ -369,7 +369,10 @@ extension MentionListener /* Private */ {
 extension MentionListener: UITextViewDelegate {
     public func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange,
                          replacementText text: String) -> Bool {
-        _ = delegate?.textView?(textView, shouldChangeTextIn: range, replacementText: text)
+        let delegateResult = delegate?.textView?(textView, shouldChangeTextIn: range, replacementText: text)
+        guard delegateResult ?? true else {
+            return false 
+        }
 
         textView.typingAttributes = defaultTextAttributes.dictionary
 

--- a/Classes/MentionListener.swift
+++ b/Classes/MentionListener.swift
@@ -37,6 +37,11 @@ public class MentionListener: NSObject {
     private let considerTextBefore: Bool
 
     /**
+     @brief Replace an edited mention with a newly created one
+     */
+    private let replaceEditedMention: Bool
+
+    /**
      @brief Triggers to start a mention. Default: @
      */
     private let triggers: [String]
@@ -143,6 +148,7 @@ public class MentionListener: NSObject {
         cooldownInterval: TimeInterval = 0.5,
         searchSpaces: Bool = false,
         considerTextBefore: Bool = true,
+        replaceEditedMention: Bool = false,
         removeEntireMention: Bool = false,
         hideMentions: @escaping () -> Void,
         didHandleMentionOnReturn: @escaping () -> Bool,
@@ -159,6 +165,7 @@ public class MentionListener: NSObject {
 
         self.searchSpaces = searchSpaces
         self.considerTextBefore = considerTextBefore
+        self.replaceEditedMention = replaceEditedMention
         self.mentionsTextView = mentionsTextView
         self.delegate = delegate
         self.spaceAfterMention = spaceAfterMention
@@ -211,7 +218,9 @@ extension MentionListener /* Public */ {
      */
     @discardableResult public func addMention(_ createMention: CreateMention) -> Bool {
         guard currentMentionRange.location != NSNotFound else { return false }
-
+        if let mention = mentions |> mentionBeingEdited(at: currentMentionRange), replaceEditedMention {
+            mention |> clearMention()
+        }
         mentions = mentions
             |> add(createMention, spaceAfterMention: spaceAfterMention, at: currentMentionRange)
 
@@ -307,7 +316,6 @@ extension MentionListener /* Private */ {
                 return
             }
         }
-
         hideMentions()
     }
 

--- a/SZMentionsSwift.podspec
+++ b/SZMentionsSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "SZMentionsSwift"
-  s.version          = "2.1.3"
+  s.version          = "2.1.4"
   s.summary          = "Highly customizable mentions library"
   s.description      = "Mentions library used to help manage mentions in a UITextView"
   s.homepage         = "http://www.stevenzweier.com"

--- a/SZMentionsSwift.podspec
+++ b/SZMentionsSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "SZMentionsSwift"
-  s.version          = "2.1.6"
+  s.version          = "2.1.3"
   s.summary          = "Highly customizable mentions library"
   s.description      = "Mentions library used to help manage mentions in a UITextView"
   s.homepage         = "http://www.stevenzweier.com"

--- a/SZMentionsSwift.podspec
+++ b/SZMentionsSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "SZMentionsSwift"
-  s.version          = "2.1.5"
+  s.version          = "2.1.3"
   s.summary          = "Highly customizable mentions library"
   s.description      = "Mentions library used to help manage mentions in a UITextView"
   s.homepage         = "http://www.stevenzweier.com"

--- a/SZMentionsSwift.podspec
+++ b/SZMentionsSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "SZMentionsSwift"
-  s.version          = "2.1.3"
+  s.version          = "2.1.6"
   s.summary          = "Highly customizable mentions library"
   s.description      = "Mentions library used to help manage mentions in a UITextView"
   s.homepage         = "http://www.stevenzweier.com"

--- a/SZMentionsSwift.podspec
+++ b/SZMentionsSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "SZMentionsSwift"
-  s.version          = "2.1.4"
+  s.version          = "2.1.5"
   s.summary          = "Highly customizable mentions library"
   s.description      = "Mentions library used to help manage mentions in a UITextView"
   s.homepage         = "http://www.stevenzweier.com"


### PR DESCRIPTION
- Added a callback that helps with handling of the deleted mention.
- Added a flag 'replaceEditedMention'. With it set to true, the edited mention will be fully replaced with a new one. The default value is false in order to preserve original behaviour.
- Added a flag 'considerTextBefore'. With it set to false, mentioning can be triggered without " " before the trigger symbols.  The default value is true in order to preserve original behaviour.